### PR TITLE
Fix spelling errors and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 Calculates the odds in an Axis & Allies battle.  
 
 Uses [binomial probability distribution function](https://en.wikipedia.org/wiki/Binomial_distribution) to calculate an exact answer rather than simulating battles.
-Then recursively calulates the odds on all of those outcomes to calculate the final odds.
+Then recursively calculates the odds on all of those outcomes to calculate the final odds.
 
 ## Usage
 
 ### Positional units
 Infantry
-Artillary
+Artillery
 Tanks
 Fighters
 Bombers
@@ -16,7 +16,7 @@ Bombers
 ### Command line example
 `$ aacalc.pl 10 0 1 0 0  8 0 2 1 0`
 
-This will calulate the odds of:
+This will calculate the odds of:
 >10 Infantry
 >1 Tank
 

--- a/aacalc.pl
+++ b/aacalc.pl
@@ -15,7 +15,7 @@ memoize('binPDF');
 
 memoize('doRound');
 
-@possible_units = ( 'Infantry', 'Artillary', 'Tanks', 'Fighters', 'Bombers' );
+@possible_units = ( 'Infantry', 'Artillery', 'Tanks', 'Fighters', 'Bombers' );
 
 #------------------------------
 $VERBOSE  = 0;
@@ -26,13 +26,13 @@ if (@ARGV) {
 }
 else {
     $troops{'Att'}{'Infantry'}  = 10;
-    $troops{'Att'}{'Artillary'} = 0;
+    $troops{'Att'}{'Artillery'} = 0;
     $troops{'Att'}{'Tanks'}     = 3;
     $troops{'Att'}{'Fighters'}  = 0;
     $troops{'Att'}{'Bombers'}   = 0;
 
     $troops{'Def'}{'Infantry'}  = 10;
-    $troops{'Def'}{'Artillary'} = 0;
+    $troops{'Def'}{'Artillery'} = 0;
     $troops{'Def'}{'Tanks'}     = 0;
     $troops{'Def'}{'Fighters'}  = 0;
     $troops{'Def'}{'Bombers'}   = 0;
@@ -42,8 +42,8 @@ else {
 
 $odds{'Infantry'}{'Att'}  = 1;
 $odds{'Infantry'}{'Def'}  = 2;
-$odds{'Artillary'}{'Att'} = 2;
-$odds{'Artillary'}{'Def'} = 2;
+$odds{'Artillery'}{'Att'} = 2;
+$odds{'Artillery'}{'Def'} = 2;
 $odds{'Tanks'}{'Att'}     = 3;
 $odds{'Tanks'}{'Def'}     = 2;
 $odds{'Fighters'}{'Att'}  = 3;
@@ -55,15 +55,15 @@ $odds{'Bombers'}{'Def'}   = 1;
 print STDERR ( ( join ',', 'Outcome', 'Odds', short_units_hdr() ), "\n" )
   if $VERBOSE;
 
-# Here we do the "promotion" of troops in the presense of artillary
-# Since these troops attack as artillary, we just make them artillary
+# Here we do the "promotion" of troops in the presence of artillery
+# Since these troops attack as artillery, we just make them artillery
 # and keep track of things so we can reduce the number at the end (if
 # any are left)
 my $orig_infantry = $troops{'Att'}{'Infantry'};    #save this
 
-my $promotions = min( $troops{'Att'}{'Infantry'}, $troops{'Att'}{'Artillary'} );
+my $promotions = min( $troops{'Att'}{'Infantry'}, $troops{'Att'}{'Artillery'} );
 $troops{'Att'}{'Infantry'} -= $promotions;
-$troops{'Att'}{'Artillary'} += $promotions;
+$troops{'Att'}{'Artillery'} += $promotions;
 
 ( $win_pct, $lose_pct, $tie_pct ) = doRound( short_units(%troops) );
 
@@ -131,13 +131,13 @@ sub doRound {
     foreach $side ( 'Att', 'Def' ) {
         $max_hits{$side} = sum( values %{ $units{$side} } );
         foreach $infantry_hits ( 0 .. $units{$side}{'Infantry'} ) {
-            foreach $artillary_hits ( 0 .. $units{$side}{'Artillary'} ) {
+            foreach $artillery_hits ( 0 .. $units{$side}{'Artillery'} ) {
                 foreach $tank_hits ( 0 .. $units{$side}{'Tanks'} ) {
                     foreach $fighter_hits ( 0 .. $units{$side}{'Fighters'} ) {
                         foreach $bomber_hits ( 0 .. $units{$side}{'Bombers'} ) {
 
                             $hits_prob{$side}[ $infantry_hits +
-                              $artillary_hits +
+                              $artillery_hits +
                               $tank_hits +
                               $fighter_hits +
                               $bomber_hits ] += binPDF(
@@ -145,9 +145,9 @@ sub doRound {
                                 $units{$side}{'Infantry'},
                                 $infantry_hits
                               ) * binPDF(
-                                $odds{'Artillary'}{$side} / 6,
-                                $units{$side}{'Artillary'},
-                                $artillary_hits
+                                $odds{'Artillery'}{$side} / 6,
+                                $units{$side}{'Artillery'},
+                                $artillery_hits
                               ) * binPDF( $odds{'Tanks'}{$side} / 6,
                                 $units{$side}{'Tanks'}, $tank_hits ) * binPDF(
                                 $odds{'Fighters'}{$side} / 6,

--- a/aacalc.py
+++ b/aacalc.py
@@ -35,10 +35,10 @@ from functools import lru_cache
 
 # Global constants
 VERBOSE = 0
-POSSIBLE_UNITS = ['Infantry', 'Artillary', 'Tanks', 'Fighters', 'Bombers']
+POSSIBLE_UNITS = ['Infantry', 'Artillery', 'Tanks', 'Fighters', 'Bombers']
 ODDS = {
     'Infantry': {'Att': 1, 'Def': 2},
-    'Artillary': {'Att': 2, 'Def': 2},
+    'Artillery': {'Att': 2, 'Def': 2},
     'Tanks': {'Att': 3, 'Def': 2},
     'Fighters': {'Att': 3, 'Def': 4},
     'Bombers': {'Att': 4, 'Def': 1}
@@ -144,8 +144,8 @@ def doRound(*args):
         units = args[0]
     elif len(args) == 10:
         units = Units(args)
-        #units = {'Att': {'Infantry': args[0], 'Artillary': args[1], 'Tanks': args[2], 'Fighters': args[3], 'Bombers': args[4]},
-        #         'Def': {'Infantry': args[5], 'Artillary': args[6], 'Tanks': args[7], 'Fighters': args[8], 'Bombers': args[9]}}
+        #units = {'Att': {'Infantry': args[0], 'Artillery': args[1], 'Tanks': args[2], 'Fighters': args[3], 'Bombers': args[4]},
+        #         'Def': {'Infantry': args[5], 'Artillery': args[6], 'Tanks': args[7], 'Fighters': args[8], 'Bombers': args[9]}}
     else:
         raise ValueError("doRound expects either 1 dictionary or 10 items")
 


### PR DESCRIPTION
Corrects spelling errors in `aacalc.pl`, `aacalc.py`, and `README.md`.

- **Corrects spelling**: Changes "Artillary" to "Artillery" and "presense" to "presence" in `aacalc.pl`. Similarly, updates "Artillary" to "Artillery" in `aacalc.py` to match the correct spelling.
- **Updates documentation**: Modifies `README.md` to correct the spelling of "Artillery" 
---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/chrishodson/aacalc/tree/python-automated?shareId=4c91282c-13e4-4fac-99c4-7466dd70fa61).